### PR TITLE
fix: disable point in time recovery for dynamodb tables

### DIFF
--- a/ucan-invocation/tables/index.js
+++ b/ucan-invocation/tables/index.js
@@ -8,6 +8,11 @@ export const adminMetricsTableProps = {
   },
   // name must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'name' },
+  cdk: {
+    table: {
+      pointInTimeRecovery: false
+    }
+  }
 }
 
 /** @type TableProps */
@@ -19,4 +24,9 @@ export const spaceMetricsTableProps = {
   },
   // space+name must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'name' },
+  cdk: {
+    table: {
+      pointInTimeRecovery: false
+    }
+  }
 }

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -13,6 +13,11 @@ export const storeTableProps = {
   },
   // space + link must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'link' },
+  cdk: {
+    table: {
+      pointInTimeRecovery: false
+    }
+  }
 }
 
 /** @type TableProps */
@@ -25,4 +30,9 @@ export const uploadTableProps = {
   },
   // space + root must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'root' },
+  cdk: {
+    table: {
+      pointInTimeRecovery: false
+    }
+  }
 }


### PR DESCRIPTION
This PR removes point in time recovery for dynamodb tables here per https://github.com/web3-storage/secrets/issues/5

Once this releases, we should check https://us-west-2.console.aws.amazon.com/dynamodbv2/home?region=us-west-2#table?name=prod-w3infra-store&tab=backups to guarantee cloudformation does it. Otherwise, then we can disable it manually in the console