### PR TITLE
fix: error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "dependencies": {
         "@ipld/dag-json": "^10.1.5",
         "@web-std/stream": "^1.0.3",
-        "@web3-storage/upload-api": "^18.0.0",
+        "@web3-storage/upload-api": "^18.0.1",
         "aws-cdk-lib": "2.142.1",
         "sst": "^2.40.3"
       },
@@ -10214,9 +10214,9 @@
       }
     },
     "node_modules/@web3-storage/upload-api": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/upload-api/-/upload-api-18.0.0.tgz",
-      "integrity": "sha512-f8TXQupZfHhv9e4bcc4G+q/cDXeD6eNx5bd4x8227gLuXbEG/aeEmvOSpD2cG5Gx5Dw0lrjWZFJYG/RwopoJVQ==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/upload-api/-/upload-api-18.0.1.tgz",
+      "integrity": "sha512-A6Q4GOCoXEmTBEQfm+SEOeAGhhEzBOw/ESxbqLv6+thYx2MGQYpkdo/CgeYfQqZUVzOgdcFR8d9FQEQmhBaA0Q==",
       "dependencies": {
         "@ucanto/client": "^9.0.1",
         "@ucanto/interface": "^10.0.1",
@@ -26911,7 +26911,7 @@
         "@web3-storage/access": "^20.0.0",
         "@web3-storage/capabilities": "^17.2.0",
         "@web3-storage/did-mailto": "^2.1.0",
-        "@web3-storage/upload-api": "^18.0.0",
+        "@web3-storage/upload-api": "^18.0.1",
         "multiformats": "^13.1.0",
         "nanoid": "^5.0.2",
         "preact": "^10.14.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ipld/dag-json": "^10.1.5",
     "@web-std/stream": "^1.0.3",
-    "@web3-storage/upload-api": "^18.0.0",
+    "@web3-storage/upload-api": "^18.0.1",
     "aws-cdk-lib": "2.142.1",
     "sst": "^2.40.3"
   },

--- a/upload-api/external-services/ipni-service.js
+++ b/upload-api/external-services/ipni-service.js
@@ -107,7 +107,11 @@ export class BlockAdvertisementPublisher {
       }
       return ok({})
     } catch (/** @type {any} */ err) {
-      return error(err)
+      console.error('failed to add entries to IPNI advertisement publisher', err)
+      return error({
+        name: 'IPNIBlockAdvertPublisherAddEntriesError',
+        message: `failed to add entries to IPNI advertisement publisher: ${err.message}`
+      })
     }
   }
 }
@@ -164,7 +168,11 @@ export class BlockIndexStore {
       }
       return ok({})
     } catch (/** @type {any} */ err) {
-      return error(err)
+      console.error('failed to put records to block index', err)
+      return error({
+        name: 'BlockIndexPutRecordsError',
+        message: `failed to put records to block index: ${err.message}`
+      })
     }
   }
 }

--- a/upload-api/package.json
+++ b/upload-api/package.json
@@ -24,7 +24,7 @@
     "@web3-storage/access": "^20.0.0",
     "@web3-storage/capabilities": "^17.2.0",
     "@web3-storage/did-mailto": "^2.1.0",
-    "@web3-storage/upload-api": "^18.0.0",
+    "@web3-storage/upload-api": "^18.0.1",
     "multiformats": "^13.1.0",
     "nanoid": "^5.0.2",
     "preact": "^10.14.1",


### PR DESCRIPTION
This PR should help debugging issues uploading DAGs with MANY blocks.

Firstly it pulls in `upload-api@18.0.1` which has a [fix for returning the wrong response when we fail to extract and decode a sharded DAG index](https://github.com/storacha-network/w3up/commit/67ef2b02ab2d745e4a2f023cf03f58c2a6ee1e2f).

Secondly, it tweaks errors returned by the IPNI service to just include details of the error in the response, while logging to stderr on the server. I believe the error dynamo/SQS has a `bigint` somewhere in it, which cannot be serialized by Ucanto when retruning the response:

```
TypeError: Do not know how to serialize a BigInt
    at AgentMessageStore.write (/upload-api/stores/agent.js:57:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at handle (/node_modules/@web3-storage/upload-api/src/lib.js:111:23)
    at ucanInvocationRouter (/upload-api/functions/ucan-invocation-router.js:298:20)
    at processResult (/node_modules/src/awslambda.ts:326:50) {
  cause: TypeError: Do not know how to serialize a BigInt
      at JSON.stringify (<anonymous>)
      at assert (/upload-api/stores/agent/stream.js:136:16)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at write (/upload-api/stores/agent/stream.js:73:18)
      at AgentMessageStore.write (/upload-api/stores/agent.js:53:47)
      at handle (/node_modules/@web3-storage/upload-api/src/lib.js:111:23)
      at ucanInvocationRouter (/upload-api/functions/ucan-invocation-router.js:298:20)
      at processResult (/node_modules/src/awslambda.ts:326:50),
```