### PR TITLE
Add logging to space state changes, tests of billing usage

### DIFF
--- a/billing/functions/ucan-stream.js
+++ b/billing/functions/ucan-stream.js
@@ -38,8 +38,12 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     }
 
     const deltas = findSpaceUsageDeltas(messages)
-    if (!deltas.length) return
-
+    if (!deltas.length) {
+      console.log("No messages found that contain space usage deltas", "capabilities", messages[0].value.att.map((att) => att.can), "resources", messages[0].value.att.map((att) => att.with) )
+      return
+    }
+    console.log("Storing space usage delta", deltas[0])
+    
     const ctx = {
       spaceDiffStore: createSpaceDiffStore({ region }, { tableName: spaceDiffTable }),
       consumerStore: createConsumerStore({ region }, { tableName: consumerTable })

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -85,7 +85,7 @@ async function makeBridgeRequest(context, client, capabilities, expiration, requ
 
 test('the bridge can make various types of requests', async t => {
   const inbox = await createMailSlurpInbox()
-  const client = await setupNewClient(t.context.apiEndpoint, { inbox })
+  const { client } = await setupNewClient(t.context.apiEndpoint, { inbox })
   const spaceDID = client.currentSpace()?.did()
   if (!spaceDID) {
     t.fail('client was set up but does not have a currentSpace - this is weird!')

--- a/test/filecoin.test.js
+++ b/test/filecoin.test.js
@@ -50,7 +50,7 @@ test('w3filecoin integration flow', async t => {
   const { invocationConfig, connection } = await getClientConfig(new URL(endpoint))
 
   // setup w3up client
-  const client = await setupNewClient(endpoint, { inbox })
+  const { client } = await setupNewClient(endpoint, { inbox })
   const spaceDid = client.currentSpace()?.did()
   if (!spaceDid) {
     throw new Error('Testing space DID must be set')

--- a/test/helpers/store.js
+++ b/test/helpers/store.js
@@ -22,3 +22,62 @@ export async function waitForStoreOperationOkResult (fn, verifyResFn) {
     retries: 1e3
   })
 }
+
+/**
+ * 
+ * @param {import('@web3-storage/w3up-client').Client} client 
+ * @param {import('@web3-storage/w3up-client/account').Account} account 
+ */
+export async function getUsage(client, account) {
+  /** @type {Record<`did:${string}:${string}`, number>} */
+  const usage = {}
+  const now = new Date()
+  const period = {
+    // we may not have done a snapshot for this month _yet_, so get report
+    // from last month -> now
+    from: startOfLastMonth(now),
+    to: now,
+  }
+
+const subscriptions = await client.capability.subscription.list(account.did())
+for (const { consumers } of subscriptions.results) {
+  for (const space of consumers) {
+    try {
+      const result = await client.capability.usage.report(space, period)
+      for (const [, report] of Object.entries(result)) {
+        usage[report.space] = report.size.final
+      }
+    } catch (err) {
+      // TODO: figure out why usage/report cannot be used on old spaces 
+      console.error(err)
+    }
+  }
+}
+return usage
+}
+
+/**
+ * 
+ * @param {string | number | Date} now 
+ * @returns 
+ */
+const startOfMonth = (now) => {
+  const d = new Date(now)
+  d.setUTCDate(1)
+  d.setUTCHours(0)
+  d.setUTCMinutes(0)
+  d.setUTCSeconds(0)
+  d.setUTCMilliseconds(0)
+  return d
+}
+
+/**
+ * 
+ * @param {string | number | Date} now 
+ * @returns 
+ */
+const startOfLastMonth = (now) => {
+  const d = startOfMonth(now)
+  d.setUTCMonth(d.getUTCMonth() - 1)
+  return d
+}

--- a/test/helpers/up-client.js
+++ b/test/helpers/up-client.js
@@ -69,7 +69,7 @@ export async function setupNewClient (uploadServiceUrl, options = {}) {
     await space.save()
   }
 
-  return client
+  return { client, account }
 }
 
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -144,7 +144,7 @@ test('w3infra store/upload integration flow', async t => {
     throw new Error('no write target bucket name configure using ENV VAR `R2_CARPARK_BUCKET_NAME`')
   }
   const inbox = await createMailSlurpInbox()
-  const client = await setupNewClient(t.context.apiEndpoint, { inbox })
+  const { client } = await setupNewClient(t.context.apiEndpoint, { inbox })
   const spaceDid = client.currentSpace()?.did()
   if (!spaceDid) {
     throw new Error('Testing space DID must be set')


### PR DESCRIPTION
# Goals

Better debug https://github.com/storacha-network/project-tracking/issues/75

# Implementation

This PR does 2 things:
1. Add logging to the ucanstream handler for Billing API, to see if it is properly parsing and saving space diffs when a user uploads
2. Adds checks of before and after on usage from the billing system to the `blob` and `store` integration tests -- this is based almost exactly on the way the UsageBar component fetches data in the console.
