### PR TITLE
fix(billing): increase parallelization factor

### DIFF
--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -108,7 +108,8 @@ export function BillingStack ({ stack, app }) {
       cdk: {
         eventSource: {
           batchSize: 1,
-          startingPosition: StartingPosition.LATEST
+          startingPosition: StartingPosition.LATEST,
+          parallelizationFactor: 10
         }
       }
     }


### PR DESCRIPTION
# Goals

Help the billing iterator catch up

I think this should allow us to parallelize execution on the iterator without changing the code nor affecting other consumers.

# Implementation

Up the parallelization factor on the billing ucan stream handler to 10 -- see https://aws.amazon.com/about-aws/whats-new/2019/11/aws-lambda-supports-parallelization-factor-for-kinesis-and-dynamodb-event-sources/ -- this will allow parallelization on the same shard, but without increasing batch size (which would require logic change)