### PR TITLE
feat(billing): reuse DynamoDB and SQS clients

### DIFF
--- a/billing/queues/client.js
+++ b/billing/queues/client.js
@@ -1,12 +1,12 @@
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
 import retry from 'p-retry'
-import { QueueOperationFailure } from './lib.js'
+import { QueueOperationFailure, getSQSClient } from './lib.js'
 
 /** @param {{ region: string } | SQSClient} target */
 export const connectQueue = target =>
   target instanceof SQSClient
     ? target
-    : new SQSClient(target)
+    : getSQSClient(target.region)
 
 /**
  * @template T

--- a/billing/queues/lib.js
+++ b/billing/queues/lib.js
@@ -1,4 +1,5 @@
 import { Failure } from '@ucanto/server'
+import { SQSClient } from '@aws-sdk/client-sqs'
 
 export class QueueOperationFailure extends Failure {
   /**
@@ -14,4 +15,15 @@ export class QueueOperationFailure extends Failure {
   describe () {
     return `queue operation failed: ${this.detail}`
   }
+}
+
+/** @type {Record<string, import('@aws-sdk/client-sqs').SQSClient>} */
+const sqsClients = {}
+
+/** @param {string} region */
+export function getSQSClient (region) {
+  if (!sqsClients[region]) {
+    sqsClients[region] = new SQSClient({ region })
+  }
+  return sqsClients[region]
 }

--- a/billing/tables/client.js
+++ b/billing/tables/client.js
@@ -1,13 +1,13 @@
 import { DynamoDBClient, GetItemCommand, PutItemCommand, QueryCommand, ScanCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall, convertToAttr } from '@aws-sdk/util-dynamodb'
 import retry from 'p-retry'
-import { RecordNotFound, StoreOperationFailure } from './lib.js'
+import { RecordNotFound, StoreOperationFailure, getDynamoClient } from './lib.js'
 
 /** @param {{ region: string } | DynamoDBClient} target */
 export const connectTable = target =>
   target instanceof DynamoDBClient
     ? target
-    : new DynamoDBClient(target)
+    : getDynamoClient(target.region)
 
 /**
  * @template T

--- a/billing/tables/lib.js
+++ b/billing/tables/lib.js
@@ -1,4 +1,5 @@
 import { Failure } from '@ucanto/server'
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 
 export class StoreOperationFailure extends Failure {
   /**
@@ -34,4 +35,15 @@ export class RecordNotFound extends Failure {
   toJSON () {
     return { ...super.toJSON(), key: this.key }
   }
+}
+
+/** @type {Record<string, import('@aws-sdk/client-dynamodb').DynamoDBClient>} */
+const dynamoClients = {}
+
+/** @param {string} region */
+export function getDynamoClient (region) {
+  if (!dynamoClients[region]) {
+    dynamoClients[region] = new DynamoDBClient({ region })
+  }
+  return dynamoClients[region]
 }


### PR DESCRIPTION
As per recommendations in [Best Practices with Lambda](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.BestPracticesWithDynamoDB.html) this PR ports a small chunk of code from content claims that caches DynamoDB and SQS clients after they are created. This allows existing connections to be reused for non-cold start invocations and should lower lambda running time.