### PR TITLE
feat: reuse all AWS clients

### DIFF
--- a/billing/functions/billing-cron.js
+++ b/billing/functions/billing-cron.js
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/serverless'
-import { expect, mustGetEnv } from './lib.js'
+import { expect } from './lib.js'
 import { createCustomerStore } from '../tables/customer.js'
 import { createCustomerBillingQueue } from '../queues/customer.js'
 import { startOfLastMonth, startOfMonth } from '../lib/util.js'
 import { enqueueCustomerBillingInstructions } from '../lib/billing-cron.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/billing/functions/customer-billing-queue.js
+++ b/billing/functions/customer-billing-queue.js
@@ -1,10 +1,11 @@
 import * as Sentry from '@sentry/serverless'
-import { expect, mustGetEnv } from './lib.js'
+import { expect } from './lib.js'
 import * as BillingInstruction from '../data/customer-billing-instruction.js'
 import { createSubscriptionStore } from '../tables/subscription.js'
 import { createConsumerStore } from '../tables/consumer.js'
 import { createSpaceBillingQueue } from '../queues/space.js'
 import { enqueueSpaceBillingInstructions } from '../lib/customer-billing-queue.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/billing/functions/lib.js
+++ b/billing/functions/lib.js
@@ -1,14 +1,4 @@
 /**
- * @param {string} name
- * @returns {string}
- */
-export const mustGetEnv = name => {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing env var: ${name}`)
-  return value
-}
-
-/**
  * @template {{}} T
  * @param {import('@ucanto/interface').Result<T>} result
  * @param {string} [message]

--- a/billing/functions/space-billing-queue.js
+++ b/billing/functions/space-billing-queue.js
@@ -1,10 +1,11 @@
 import * as Sentry from '@sentry/serverless'
-import { expect, mustGetEnv } from './lib.js'
+import { expect } from './lib.js'
 import * as SpaceBillingInstruction from '../data/space-billing-instruction.js'
 import { createSpaceDiffStore } from '../tables/space-diff.js'
 import { createSpaceSnapshotStore } from '../tables/space-snapshot.js'
 import { createUsageStore } from '../tables/usage.js'
 import { calculatePeriodUsage, storeSpaceUsage } from '../lib/space-billing-queue.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/billing/functions/stripe.js
+++ b/billing/functions/stripe.js
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/serverless'
 import { Config } from 'sst/node/config'
 import Stripe from 'stripe'
-import { expect, mustGetEnv } from './lib.js'
+import { expect } from './lib.js'
 import { createCustomerStore } from '../tables/customer.js'
 import { handleCustomerSubscriptionCreated } from '../utils/stripe.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 /**
  * @typedef {import('../lib/api.js').AccountID} AccountID

--- a/billing/functions/ucan-stream.js
+++ b/billing/functions/ucan-stream.js
@@ -3,8 +3,9 @@ import { toString, fromString } from 'uint8arrays'
 import * as Link from 'multiformats/link'
 import { createSpaceDiffStore } from '../tables/space-diff.js'
 import { createConsumerStore } from '../tables/consumer.js'
-import { expect, mustGetEnv } from './lib.js'
+import { expect } from './lib.js'
 import { findSpaceUsageDeltas, storeSpaceUsageDelta } from '../lib/ucan-stream.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/billing/queues/client.js
+++ b/billing/queues/client.js
@@ -1,12 +1,13 @@
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
 import retry from 'p-retry'
-import { QueueOperationFailure, getSQSClient } from './lib.js'
+import { QueueOperationFailure } from './lib.js'
+import { getSQSClient } from '../../lib/aws/sqs.js'
 
 /** @param {{ region: string } | SQSClient} target */
 export const connectQueue = target =>
   target instanceof SQSClient
     ? target
-    : getSQSClient(target.region)
+    : getSQSClient(target)
 
 /**
  * @template T

--- a/billing/queues/lib.js
+++ b/billing/queues/lib.js
@@ -1,5 +1,4 @@
 import { Failure } from '@ucanto/server'
-import { SQSClient } from '@aws-sdk/client-sqs'
 
 export class QueueOperationFailure extends Failure {
   /**
@@ -15,15 +14,4 @@ export class QueueOperationFailure extends Failure {
   describe () {
     return `queue operation failed: ${this.detail}`
   }
-}
-
-/** @type {Record<string, import('@aws-sdk/client-sqs').SQSClient>} */
-const sqsClients = {}
-
-/** @param {string} region */
-export function getSQSClient (region) {
-  if (!sqsClients[region]) {
-    sqsClients[region] = new SQSClient({ region })
-  }
-  return sqsClients[region]
 }

--- a/billing/scripts/dry-run.js
+++ b/billing/scripts/dry-run.js
@@ -10,7 +10,7 @@ import all from 'p-all'
 import { startOfLastMonth, startOfMonth } from '../lib/util.js'
 import { calculateCost, createMemoryQueue, createMemoryStore } from './helpers.js'
 import { EndOfQueue } from '../test/helpers/queue.js'
-import { expect, mustGetEnv } from '../functions/lib.js'
+import { expect } from '../functions/lib.js'
 import * as BillingCron from '../lib/billing-cron.js'
 import * as CustomerBillingQueue from '../lib/customer-billing-queue.js'
 import * as SpaceBillingQueue from '../lib/space-billing-queue.js'
@@ -21,6 +21,7 @@ import { createSpaceDiffStore } from '../tables/space-diff.js'
 import { createSpaceSnapshotStore } from '../tables/space-snapshot.js'
 import * as Usage from '../data/usage.js'
 import * as SpaceSnapshot from '../data/space-snapshot.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 /** @typedef {import('../lib/api.js').Usage & import('../lib/api.js').SpaceSnapshot} UsageAndSnapshot */
 

--- a/billing/tables/client.js
+++ b/billing/tables/client.js
@@ -1,13 +1,14 @@
 import { DynamoDBClient, GetItemCommand, PutItemCommand, QueryCommand, ScanCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall, convertToAttr } from '@aws-sdk/util-dynamodb'
 import retry from 'p-retry'
-import { RecordNotFound, StoreOperationFailure, getDynamoClient } from './lib.js'
+import { RecordNotFound, StoreOperationFailure } from './lib.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /** @param {{ region: string } | DynamoDBClient} target */
 export const connectTable = target =>
   target instanceof DynamoDBClient
     ? target
-    : getDynamoClient(target.region)
+    : getDynamoClient(target)
 
 /**
  * @template T

--- a/billing/tables/lib.js
+++ b/billing/tables/lib.js
@@ -1,5 +1,4 @@
 import { Failure } from '@ucanto/server'
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 
 export class StoreOperationFailure extends Failure {
   /**

--- a/billing/tables/lib.js
+++ b/billing/tables/lib.js
@@ -36,14 +36,3 @@ export class RecordNotFound extends Failure {
     return { ...super.toJSON(), key: this.key }
   }
 }
-
-/** @type {Record<string, import('@aws-sdk/client-dynamodb').DynamoDBClient>} */
-const dynamoClients = {}
-
-/** @param {string} region */
-export function getDynamoClient (region) {
-  if (!dynamoClients[region]) {
-    dynamoClients[region] = new DynamoDBClient({ region })
-  }
-  return dynamoClients[region]
-}

--- a/carpark/event-bus/eipfs-indexer.js
+++ b/carpark/event-bus/eipfs-indexer.js
@@ -1,4 +1,4 @@
-import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+import { SendMessageCommand } from '@aws-sdk/client-sqs'
 import * as Sentry from '@sentry/serverless'
 import { mustGetEnv } from '../../lib/env.js'
 import { getSQSClient } from '../../lib/aws/sqs.js'
@@ -14,7 +14,7 @@ Sentry.AWSLambda.init({
 
 /**
  * @param {import('./source').EventBridgeEvent} event 
- * @param {SQSClient} client
+ * @param {import('@aws-sdk/client-sqs').SQSClient} client
  * @param {string} queueUrl
  */
 export async function eipfsHandler(event, client, queueUrl) {

--- a/carpark/event-bus/eipfs-indexer.js
+++ b/carpark/event-bus/eipfs-indexer.js
@@ -1,5 +1,7 @@
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
 import * as Sentry from '@sentry/serverless'
+import { mustGetEnv } from '../../lib/env.js'
+import { getSQSClient } from '../../lib/aws/sqs.js'
 
 // https://github.com/elastic-ipfs/indexer-lambda
 const SQS_INDEXER_QUEUE_REGION = 'us-west-2'
@@ -32,7 +34,7 @@ export async function eipfsHandler(event, client, queueUrl) {
  * @param {import('./source').EventBridgeEvent} event 
  */
 async function messageHandler (event) {
-  const sqsClient = new SQSClient({
+  const sqsClient = getSQSClient({
     region: SQS_INDEXER_QUEUE_REGION,
   })
 
@@ -48,18 +50,4 @@ function getEnv() {
   return {
     EIPFS_INDEXER_SQS_URL: mustGetEnv('EIPFS_INDEXER_SQS_URL'),
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  if (!process.env[name]) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  // @ts-expect-error there will always be a string there, but typescript does not believe
-  return process.env[name]
 }

--- a/filecoin/functions/handle-cron-tick.js
+++ b/filecoin/functions/handle-cron-tick.js
@@ -9,7 +9,7 @@ import { createPieceTable } from '../store/piece.js'
 import { createTaskStore } from '../store/task.js'
 import { createReceiptStore } from '../store/receipt.js'
 import { getServiceSigner } from '../service.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/filecoin/functions/handle-filecoin-submit-message.js
+++ b/filecoin/functions/handle-filecoin-submit-message.js
@@ -5,7 +5,7 @@ import * as storefrontEvents from '@web3-storage/filecoin-api/storefront/events'
 import { createPieceTable } from '../store/piece.js'
 import { useContentStore } from '../store/content.js'
 import { decodeMessage } from '../queue/filecoin-submit-queue.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/filecoin/functions/handle-piece-insert-to-content-claim.js
+++ b/filecoin/functions/handle-piece-insert-to-content-claim.js
@@ -9,7 +9,7 @@ import * as storefrontEvents from '@web3-storage/filecoin-api/storefront/events'
 
 import { decodeRecord } from '../store/piece.js'
 import { getServiceConnection, getServiceSigner } from '../service.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/filecoin/functions/handle-piece-insert-to-filecoin-submit.js
+++ b/filecoin/functions/handle-piece-insert-to-filecoin-submit.js
@@ -9,7 +9,7 @@ import * as storefrontEvents from '@web3-storage/filecoin-api/storefront/events'
 
 import { decodeRecord } from '../store/piece.js'
 import { getServiceConnection, getServiceSigner } from '../service.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/filecoin/functions/handle-piece-offer-message.js
+++ b/filecoin/functions/handle-piece-offer-message.js
@@ -8,7 +8,7 @@ import * as storefrontEvents from '@web3-storage/filecoin-api/storefront/events'
 
 import { decodeMessage } from '../queue/piece-offer-queue.js'
 import { getServiceConnection, getServiceSigner } from '../service.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/filecoin/functions/handle-piece-status-update.js
+++ b/filecoin/functions/handle-piece-status-update.js
@@ -9,7 +9,7 @@ import * as storefrontEvents from '@web3-storage/filecoin-api/storefront/events'
 
 import { decodeRecord } from '../store/piece.js'
 import { getServiceConnection, getServiceSigner } from '../service.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/filecoin/functions/metrics-aggregate-offer-and-accept-total.js
+++ b/filecoin/functions/metrics-aggregate-offer-and-accept-total.js
@@ -7,7 +7,7 @@ import { updateAggregateOfferTotal, updateAggregateAcceptTotal } from '../metric
 import { createWorkflowStore } from '../store/workflow.js'
 import { createInvocationStore } from '../store/invocation.js'
 import { createFilecoinMetricsTable } from '../store/metrics.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/filecoin/functions/piece-cid-compute.js
+++ b/filecoin/functions/piece-cid-compute.js
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/serverless'
-import { S3Client } from '@aws-sdk/client-s3'
 import { Config } from 'sst/node/config'
 import { Storefront } from '@web3-storage/filecoin-client'
 import * as Delegation from '@ucanto/core/delegation'
@@ -8,7 +7,8 @@ import * as DID from '@ipld/dag-ucan/did'
 
 import { computePieceCid } from '../index.js'
 import { getServiceConnection, getServiceSigner } from '../service.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -68,7 +68,7 @@ async function computeHandler (event) {
     throw new Error('Unexpected sqs record format')
   }
 
-  const s3Client = new S3Client({ region: record.bucketRegion })
+  const s3Client = getS3Client({ region: record.bucketRegion })
 
   // Compute piece for record
   const { error, ok } = await computePieceCid({

--- a/filecoin/functions/utils.js
+++ b/filecoin/functions/utils.js
@@ -1,9 +1,0 @@
-/**
- * @param {string} name 
- * @returns {string}
- */
-export function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing env var: ${name}`)
-  return value
-}

--- a/filecoin/queue/index.js
+++ b/filecoin/queue/index.js
@@ -1,4 +1,5 @@
 import { SQSClient } from '@aws-sdk/client-sqs'
+import { getSQSClient } from '../../lib/aws/sqs.js'
 
 /**
  * @param {import('./types.js').QueueConnect | SQSClient} target 
@@ -7,5 +8,5 @@ export function connectQueue (target) {
   if (target instanceof SQSClient) {
     return target
   }
-  return new SQSClient(target)
+  return getSQSClient(target)
 }

--- a/filecoin/store/invocation.js
+++ b/filecoin/store/invocation.js
@@ -1,6 +1,7 @@
 import { S3Client } from '@aws-sdk/client-s3'
 import { parseLink } from '@ucanto/core'
 import * as Store from '../../upload-api/stores/agent/store.js'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
@@ -11,7 +12,7 @@ import * as Store from '../../upload-api/stores/agent/store.js'
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createInvocationStore(region, bucketName, options = {}) {
-  const s3client = new S3Client({
+  const s3client = getS3Client({
     region,
     ...options,
   })

--- a/filecoin/store/invocation.js
+++ b/filecoin/store/invocation.js
@@ -1,4 +1,3 @@
-import { S3Client } from '@aws-sdk/client-s3'
 import { parseLink } from '@ucanto/core'
 import * as Store from '../../upload-api/stores/agent/store.js'
 import { getS3Client } from '../../lib/aws/s3.js'
@@ -20,7 +19,7 @@ export function createInvocationStore(region, bucketName, options = {}) {
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} bucketName
  * @returns {import('../types').InvocationBucket}
  */

--- a/filecoin/store/metrics.js
+++ b/filecoin/store/metrics.js
@@ -1,5 +1,4 @@
 import {
-  DynamoDBClient,
   TransactWriteItemsCommand,
   UpdateItemCommand
 } from '@aws-sdk/client-dynamodb'
@@ -24,7 +23,7 @@ export function createFilecoinMetricsTable (region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('../types').FilecoinMetricsStore}
  */

--- a/filecoin/store/metrics.js
+++ b/filecoin/store/metrics.js
@@ -4,6 +4,7 @@ import {
   UpdateItemCommand
 } from '@aws-sdk/client-dynamodb'
 import { marshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * Abstraction layer to handle operations on metrics table.
@@ -14,7 +15,7 @@ import { marshall } from '@aws-sdk/util-dynamodb'
  * @param {string} [options.endpoint]
  */
 export function createFilecoinMetricsTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/filecoin/store/piece.js
+++ b/filecoin/store/piece.js
@@ -9,6 +9,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { parseLink } from '@ucanto/server'
 
 import { StoreOperationFailed, RecordNotFound } from '@web3-storage/filecoin-api/errors'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * @typedef {'submitted' | 'accepted' | 'invalid'} PieceStatus
@@ -138,7 +139,7 @@ const encodeQueryProps = (recordKey) => {
  * @returns {import('@web3-storage/filecoin-api/storefront/api').PieceStore}
  */
 export function createPieceTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint
   })

--- a/filecoin/store/piece.js
+++ b/filecoin/store/piece.js
@@ -1,5 +1,4 @@
 import {
-  DynamoDBClient,
   PutItemCommand,
   GetItemCommand,
   UpdateItemCommand,
@@ -148,7 +147,7 @@ export function createPieceTable (region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('@web3-storage/filecoin-api/storefront/api').PieceStore}
  */

--- a/filecoin/store/receipt.js
+++ b/filecoin/store/receipt.js
@@ -1,4 +1,3 @@
-import { S3Client } from '@aws-sdk/client-s3'
 import { StoreOperationFailed } from '@web3-storage/filecoin-api/errors'
 import * as Store from '../../upload-api/stores/agent/store.js'
 import { getS3Client } from '../../lib/aws/s3.js'
@@ -21,7 +20,7 @@ export function createReceiptStore(region, invocationBucketName, workflowBucketN
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} invocationBucketName
  * @param {string} workflowBucketName
  * @returns {import('@web3-storage/filecoin-api/storefront/api').ReceiptStore}

--- a/filecoin/store/receipt.js
+++ b/filecoin/store/receipt.js
@@ -1,6 +1,7 @@
 import { S3Client } from '@aws-sdk/client-s3'
 import { StoreOperationFailed } from '@web3-storage/filecoin-api/errors'
 import * as Store from '../../upload-api/stores/agent/store.js'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
@@ -12,7 +13,7 @@ import * as Store from '../../upload-api/stores/agent/store.js'
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createReceiptStore(region, invocationBucketName, workflowBucketName, options = {}) {
-  const s3client = new S3Client({
+  const s3client = getS3Client({
     region,
     ...options,
   })

--- a/filecoin/store/task.js
+++ b/filecoin/store/task.js
@@ -1,4 +1,3 @@
-import { S3Client } from '@aws-sdk/client-s3'
 import { StoreOperationFailed } from '@web3-storage/filecoin-api/errors'
 import * as Store from '../../upload-api/stores/agent/store.js'
 import { getS3Client } from '../../lib/aws/s3.js'
@@ -21,7 +20,7 @@ export function createTaskStore(region, invocationBucketName, workflowBucketName
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} invocationBucketName
  * @param {string} workflowBucketName
  * @returns {import('@web3-storage/filecoin-api/storefront/api').TaskStore}

--- a/filecoin/store/task.js
+++ b/filecoin/store/task.js
@@ -1,6 +1,7 @@
 import { S3Client } from '@aws-sdk/client-s3'
 import { StoreOperationFailed } from '@web3-storage/filecoin-api/errors'
 import * as Store from '../../upload-api/stores/agent/store.js'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
@@ -12,7 +13,7 @@ import * as Store from '../../upload-api/stores/agent/store.js'
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createTaskStore(region, invocationBucketName, workflowBucketName, options = {}) {
-  const s3client = new S3Client({
+  const s3client = getS3Client({
     region,
     ...options,
   })

--- a/filecoin/store/workflow.js
+++ b/filecoin/store/workflow.js
@@ -2,6 +2,7 @@ import {
   S3Client,
   GetObjectCommand,
 } from '@aws-sdk/client-s3'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
@@ -12,7 +13,7 @@ import {
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createWorkflowStore(region, bucketName, options = {}) {
-  const s3client = new S3Client({
+  const s3client = getS3Client({
     region,
     ...options,
   })

--- a/filecoin/store/workflow.js
+++ b/filecoin/store/workflow.js
@@ -1,7 +1,4 @@
-import {
-  S3Client,
-  GetObjectCommand,
-} from '@aws-sdk/client-s3'
+import { GetObjectCommand } from '@aws-sdk/client-s3'
 import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
@@ -21,7 +18,7 @@ export function createWorkflowStore(region, bucketName, options = {}) {
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} bucketName
  * @returns {import('../types').WorkflowBucket}
  */

--- a/indexer/functions/handle-block-advert-publish-message.js
+++ b/indexer/functions/handle-block-advert-publish-message.js
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/serverless'
-import { SQSClient } from '@aws-sdk/client-sqs'
 import * as dagJSON from '@ipld/dag-json'
 import * as Digest from 'multiformats/hashes/digest'
-import { mustGetEnv } from './lib.js'
 import { publishBlockAdvertisement } from '../lib/block-advert-publisher.js'
 import { createMultihashesQueue } from '../queues/multihashes.js'
+import { mustGetEnv } from '../../lib/env.js'
+import { getSQSClient } from '../../lib/aws/sqs.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -26,7 +26,7 @@ const handleBlockAdvertPublishMessage = async (sqsEvent) => {
   const advert = decodeMessage(sqsEvent.Records[0].body)
   const url = new URL(mustGetEnv('MULTIHASHES_QUEUE_URL'))
   const region = mustGetEnv('INDEXER_REGION')
-  const client = new SQSClient({ region })
+  const client = getSQSClient({ region })
   const multihashesQueue = createMultihashesQueue(client, { url })
 
   const { ok, error } = await publishBlockAdvertisement({ multihashesQueue }, advert)

--- a/indexer/functions/handle-block-index-writer-message.js
+++ b/indexer/functions/handle-block-index-writer-message.js
@@ -2,9 +2,10 @@ import * as Sentry from '@sentry/serverless'
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import * as dagJSON from '@ipld/dag-json'
 import * as Digest from 'multiformats/hashes/digest'
-import { mustGetEnv } from './lib.js'
 import { writeBlockIndexEntries } from '../lib/block-index-writer.js'
 import { createBlocksCarsPositionStore } from '../tables/blocks-cars-position.js'
+import { mustGetEnv } from '../../lib/env.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -26,7 +27,7 @@ const handleBlockIndexWriterMessage = async (sqsEvent) => {
   const entries = decodeMessage(sqsEvent.Records[0].body)
   const tableName = mustGetEnv('BLOCKS_CAR_POSITION_TABLE_NAME')
   const region = mustGetEnv('INDEXER_REGION')
-  const client = new DynamoDBClient({ region })
+  const client = getDynamoClient({ region })
   const blocksCarsPositionStore = createBlocksCarsPositionStore(client, { tableName })
 
   const { ok, error } = await writeBlockIndexEntries({ blocksCarsPositionStore }, entries)

--- a/indexer/functions/handle-block-index-writer-message.js
+++ b/indexer/functions/handle-block-index-writer-message.js
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/serverless'
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import * as dagJSON from '@ipld/dag-json'
 import * as Digest from 'multiformats/hashes/digest'
 import { writeBlockIndexEntries } from '../lib/block-index-writer.js'

--- a/indexer/queues/client.js
+++ b/indexer/queues/client.js
@@ -2,6 +2,7 @@ import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs'
 import retry from 'p-retry'
 import { webcrypto } from 'one-webcrypto'
 import { QueueOperationFailure } from './lib.js'
+import { getSQSClient } from '../../lib/aws/sqs.js'
 
 /** The maximum size an SQS batch can be. */
 export const MAX_BATCH_SIZE = 10
@@ -10,7 +11,7 @@ export const MAX_BATCH_SIZE = 10
 export const connectQueue = target =>
   target instanceof SQSClient
     ? target
-    : new SQSClient(target)
+    : getSQSClient(target)
 
 /**
  * @template T

--- a/indexer/tables/client.js
+++ b/indexer/tables/client.js
@@ -2,6 +2,7 @@ import { BatchWriteItemCommand, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { marshall } from '@aws-sdk/util-dynamodb'
 import retry from 'p-retry'
 import { StoreOperationFailure } from './lib.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /** The maximum size a DynamoDB batch can be. */
 export const MAX_BATCH_SIZE = 25
@@ -10,7 +11,7 @@ export const MAX_BATCH_SIZE = 25
 export const connectTable = target =>
   target instanceof DynamoDBClient
     ? target
-    : new DynamoDBClient(target)
+    : getDynamoClient(target)
 
 /**
  * @template T

--- a/lib/aws/dynamo.js
+++ b/lib/aws/dynamo.js
@@ -1,0 +1,13 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+
+/** @type {Record<string, import('@aws-sdk/client-dynamodb').DynamoDBClient>} */
+const dynamoClients = {}
+
+/** @param {{ region: string, endpoint?: string }} config */
+export function getDynamoClient (config) {
+  const key = `${config.region}#${config.endpoint ?? 'default'}`
+  if (!dynamoClients[key]) {
+    dynamoClients[key] = new DynamoDBClient(config)
+  }
+  return dynamoClients[key]
+}

--- a/lib/aws/s3.js
+++ b/lib/aws/s3.js
@@ -2,11 +2,11 @@ import { S3Client } from '@aws-sdk/client-s3'
 
 /**
  * @typedef {{
-*   region: string
-*   endpoint?: string
-*   credentials?: { accessKeyId: string, secretAccessKey: string }
-* }} Address
-*/
+ *   region: string
+ *   endpoint?: string
+ *   credentials?: { accessKeyId: string, secretAccessKey: string }
+ * }} Address
+ */
 
 /** @type {Record<string, import('@aws-sdk/client-s3').S3Client>} */
 const s3Clients = {}

--- a/lib/aws/s3.js
+++ b/lib/aws/s3.js
@@ -1,0 +1,21 @@
+import { S3Client } from '@aws-sdk/client-s3'
+
+/**
+ * @typedef {{
+*   region: string
+*   endpoint?: string
+*   credentials?: { accessKeyId: string, secretAccessKey: string }
+* }} Address
+*/
+
+/** @type {Record<string, import('@aws-sdk/client-s3').S3Client>} */
+const s3Clients = {}
+
+/** @param {Address} config */
+export function getS3Client (config) {
+  const key = `${config.region}#${config.endpoint ?? 'default'}#${config.credentials?.accessKeyId ?? 'default'}`
+  if (!s3Clients[key]) {
+    s3Clients[key] = new S3Client(config)
+  }
+  return s3Clients[key]
+}

--- a/lib/aws/sqs.js
+++ b/lib/aws/sqs.js
@@ -1,0 +1,12 @@
+import { SQSClient } from '@aws-sdk/client-sqs'
+
+/** @type {Record<string, import('@aws-sdk/client-sqs').SQSClient>} */
+const sqsClients = {}
+
+/** @param {{ region: string }} config */
+export function getSQSClient (config) {
+  if (!sqsClients[config.region]) {
+    sqsClients[config.region] = new SQSClient(config)
+  }
+  return sqsClients[config.region]
+}

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,4 +1,6 @@
 /**
+ * Get the environment variable or throw an error if not set.
+ *
  * @param {string} name
  * @returns {string}
  */

--- a/roundabout/utils.js
+++ b/roundabout/utils.js
@@ -1,3 +1,4 @@
+import { mustGetEnv } from '../lib/env.js'
 import { CAR_CODE } from './constants.js'
 
 // Per https://developers.cloudflare.com/r2/api/s3/presigned-urls/
@@ -45,17 +46,6 @@ export function getEnv() {
     BUCKET_SECRET_ACCESS_KEY: mustGetEnv('BUCKET_SECRET_ACCESS_KEY'),
     BUCKET_NAME: mustGetEnv('BUCKET_NAME')
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing env var: ${name}`)
-  return value
 }
 
 /**

--- a/stacks/carpark-stack.js
+++ b/stacks/carpark-stack.js
@@ -9,6 +9,7 @@ import * as sqs from 'aws-cdk-lib/aws-sqs'
 import { BusStack } from './bus-stack.js'
 import { CARPARK_EVENT_BRIDGE_SOURCE_EVENT } from '../carpark/event-bus/source.js'
 import { getBucketConfig, setupSentry } from './config.js'
+import { mustGetEnv } from '../lib/env.js'
 
 /**
  * @param {import('sst/constructs').StackContext} properties
@@ -94,18 +95,4 @@ function getEnv() {
     EIPFS_INDEXER_SQS_ARN: mustGetEnv('EIPFS_INDEXER_SQS_ARN'),
     EIPFS_INDEXER_SQS_URL: mustGetEnv('EIPFS_INDEXER_SQS_URL'),
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  if (!process.env[name]) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  // @ts-expect-error there will always be a string there, but typescript does not believe
-  return process.env[name]
 }

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -2,6 +2,7 @@ import { Duration, RemovalPolicy } from 'aws-cdk-lib'
 import { createRequire } from 'module'
 import { StartingPosition } from 'aws-cdk-lib/aws-lambda'
 import git from 'git-rev-sync'
+import { mustGetEnv } from '../lib/env.js'
 
 /**
  * Get nicer bucket names
@@ -184,18 +185,4 @@ export function getEnv() {
     DISABLE_PIECE_CID_COMPUTE: process.env.DISABLE_PIECE_CID_COMPUTE ?? '',
     START_FILECOIN_METRICS_EPOCH_MS: process.env.START_FILECOIN_METRICS_EPOCH_MS ?? ''
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  if (!process.env[name]) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  // @ts-expect-error there will always be a string there, but typescript does not believe
-  return process.env[name]
 }

--- a/tools/d1-migration/add-to-dynamo.js
+++ b/tools/d1-migration/add-to-dynamo.js
@@ -6,6 +6,7 @@ import { marshall } from '@aws-sdk/util-dynamodb'
 import { CBOR } from '@ucanto/server'
 
 import { exec as childProcessExec } from 'child_process'
+import { mustGetEnv } from '../../lib/env.js'
 
 /**
  * 
@@ -179,20 +180,6 @@ function getEnv () {
     SUBSCRIPTIONS_TABLE_NAME: process.env.SUBSCRIPTIONS_TABLE_NAME ?? 'subscriptions',
     CONSUMERS_TABLE_NAME: process.env.CONSUMERS_TABLE_NAME ?? 'consumers',
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  return value
 }
 
 /**

--- a/tools/d1-migration/print-d1-emails.js
+++ b/tools/d1-migration/print-d1-emails.js
@@ -1,5 +1,6 @@
 import * as DidMailto from '@web3-storage/did-mailto'
 import { exec as childProcessExec } from 'child_process'
+import { mustGetEnv } from '../../lib/env.js'
 
 /**
  * 
@@ -35,20 +36,6 @@ function getEnv () {
   return {
     STAGE: mustGetEnv('STAGE'),
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  return value
 }
 
 export async function printD1ProvisionsEmails () {

--- a/tools/d1-migration/verify-d1-dynamo-migration.js
+++ b/tools/d1-migration/verify-d1-dynamo-migration.js
@@ -7,6 +7,7 @@ import {
 import { CBOR } from '@ucanto/server'
 
 import { exec as childProcessExec } from 'child_process'
+import { mustGetEnv } from '../../lib/env.js'
 
 /**
  * 
@@ -219,20 +220,6 @@ function getEnv () {
     SUBSCRIPTIONS_TABLE_NAME: process.env.SUBSCRIPTIONS_TABLE_NAME ?? 'subscriptions',
     CONSUMERS_TABLE_NAME: process.env.CONSUMERS_TABLE_NAME ?? 'consumers',
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  return value
 }
 
 /**

--- a/tools/fetch-metrics-for-space.js
+++ b/tools/fetch-metrics-for-space.js
@@ -3,6 +3,7 @@ import {
   QueryCommand
 } from '@aws-sdk/client-dynamodb'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
+import { mustGetEnv } from '../lib/env.js'
 
 export async function fetchMetricsForSpaceCmd () {
   const {
@@ -56,20 +57,6 @@ function getEnv() {
     SPACE_DID: mustGetEnv('SPACE_DID'),
     TABLE_NAME: mustGetEnv('TABLE_NAME'),
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  return value
 }
 
 /**

--- a/tools/follow-filecoin-receipt-chain.js
+++ b/tools/follow-filecoin-receipt-chain.js
@@ -6,6 +6,7 @@ import { Piece } from '@web3-storage/data-segment'
 import { getServiceSigner } from '../filecoin/service.js'
 import { createPieceTable } from '../filecoin/store/piece.js'
 import { createReceiptStore as createFilecoinReceiptStore } from '../filecoin/store/receipt.js'
+import { mustGetEnv } from '../lib/env.js'
 
 export async function followFilecoinReceiptChain () {
   const {
@@ -118,20 +119,6 @@ function getEnv() {
     PIECE_CID: mustGetEnv('PIECE_CID'),
     PRIVATE_KEY: mustGetEnv('PRIVATE_KEY'),
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  return value
 }
 
 /**

--- a/tools/get-oldest-pieces-pending-deals.js
+++ b/tools/get-oldest-pieces-pending-deals.js
@@ -1,4 +1,5 @@
 import { createPieceTable } from '../filecoin/store/piece.js'
+import { mustGetEnv } from '../lib/env.js'
 
 export async function getOldestPiecesPendingDeals () {
   const {
@@ -34,20 +35,6 @@ function getEnv() {
   return {
     ENV: mustGetEnv('ENV'),
   }
-}
-
-/**
- * 
- * @param {string} name 
- * @returns {string}
- */
-function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`Missing env var: ${name}`)
-  }
-
-  return value
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,6 @@
     "stripInternal": true,
     "resolveJsonModule": true,
   },
-  "include": [ "billing", "indexer", "upload-api", "stacks", "carpark", "replicator", "ucan-invocation", "filecoin", "tools" ],
+  "include": [ "billing", "indexer", "upload-api", "stacks", "carpark", "replicator", "ucan-invocation", "filecoin", "tools", "lib" ],
   "exclude": [ "billing/coverage" ]
 }

--- a/upload-api/buckets/car-store.js
+++ b/upload-api/buckets/car-store.js
@@ -1,8 +1,4 @@
-import {
-  S3Client,
-  HeadObjectCommand,
-  PutObjectCommand,
-} from '@aws-sdk/client-s3'
+import { HeadObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
 import { base64pad } from 'multiformats/bases/base64'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { getS3Client } from '../../lib/aws/s3.js'
@@ -23,8 +19,7 @@ export function createCarStore(region, bucketName, options) {
 }
 
 /**
- *
- * @param {S3Client} s3
+ * @param {import('@aws-sdk/client-s3').S3Client} s3
  * @param {string} bucketName
  * @returns {import('../types').CarStore}
  */

--- a/upload-api/buckets/car-store.js
+++ b/upload-api/buckets/car-store.js
@@ -5,6 +5,7 @@ import {
 } from '@aws-sdk/client-s3'
 import { base64pad } from 'multiformats/bases/base64'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing CAR files.
@@ -14,7 +15,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createCarStore(region, bucketName, options) {
-  const s3 = new S3Client({
+  const s3 = getS3Client({
     region,
     ...options,
   })

--- a/upload-api/buckets/delegations-store.js
+++ b/upload-api/buckets/delegations-store.js
@@ -1,8 +1,4 @@
-import {
-  S3Client,
-  PutObjectCommand,
-  GetObjectCommand,
-} from '@aws-sdk/client-s3'
+import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
 import { base32 } from 'multiformats/bases/base32'
 import { getS3Client } from '../../lib/aws/s3.js'
@@ -40,7 +36,7 @@ function createDelegationsBucketKey (cid) {
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} bucketName
  * @returns {import('../types').DelegationsBucket}
  */

--- a/upload-api/buckets/delegations-store.js
+++ b/upload-api/buckets/delegations-store.js
@@ -5,6 +5,7 @@ import {
 } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
 import { base32 } from 'multiformats/bases/base32'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /** @typedef {import('multiformats/cid').CID} CID */
 
@@ -17,7 +18,7 @@ import { base32 } from 'multiformats/bases/base32'
  * @param {string} bucketName
  */
 export function createDelegationsStore(endpoint, accessKeyId, secretAccessKey, bucketName){
-  const s3Client = new S3Client({
+  const s3Client = getS3Client({
     region: 'auto',
     endpoint,
     credentials: {

--- a/upload-api/buckets/invocation-store.js
+++ b/upload-api/buckets/invocation-store.js
@@ -1,8 +1,4 @@
-import {
-  S3Client,
-  PutObjectCommand,
-  ListObjectsV2Command,
-} from '@aws-sdk/client-s3'
+import { PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
 import { getS3Client } from '../../lib/aws/s3.js'
 
@@ -23,7 +19,7 @@ export function createInvocationStore(region, bucketName, options = {}) {
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} bucketName
  * @returns {import('../types').InvocationBucket}
  */

--- a/upload-api/buckets/invocation-store.js
+++ b/upload-api/buckets/invocation-store.js
@@ -4,6 +4,7 @@ import {
   ListObjectsV2Command,
 } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
@@ -14,7 +15,7 @@ import pRetry from 'p-retry'
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createInvocationStore(region, bucketName, options = {}) {
-  const s3client = new S3Client({
+  const s3client = getS3Client({
     region,
     ...options,
   })

--- a/upload-api/buckets/task-store.js
+++ b/upload-api/buckets/task-store.js
@@ -1,7 +1,4 @@
-import {
-  S3Client,
-  PutObjectCommand,
-} from '@aws-sdk/client-s3'
+import { PutObjectCommand } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
 import { getS3Client } from '../../lib/aws/s3.js'
 
@@ -22,7 +19,7 @@ export function createTaskStore(region, bucketName, options = {}) {
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} bucketName
  * @returns {import('../types').TaskBucket}
  */

--- a/upload-api/buckets/task-store.js
+++ b/upload-api/buckets/task-store.js
@@ -3,6 +3,7 @@ import {
   PutObjectCommand,
 } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
@@ -13,7 +14,7 @@ import pRetry from 'p-retry'
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createTaskStore(region, bucketName, options = {}) {
-  const s3client = new S3Client({
+  const s3client = getS3Client({
     region,
     ...options,
   })

--- a/upload-api/buckets/workflow-store.js
+++ b/upload-api/buckets/workflow-store.js
@@ -1,8 +1,4 @@
-import {
-  S3Client,
-  PutObjectCommand,
-  GetObjectCommand,
-} from '@aws-sdk/client-s3'
+import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
 import { getS3Client } from '../../lib/aws/s3.js'
 
@@ -23,7 +19,7 @@ export function createWorkflowStore(region, bucketName, options = {}) {
 }
 
 /**
- * @param {S3Client} s3client
+ * @param {import('@aws-sdk/client-s3').S3Client} s3client
  * @param {string} bucketName
  * @returns {import('../types').WorkflowBucket}
  */

--- a/upload-api/buckets/workflow-store.js
+++ b/upload-api/buckets/workflow-store.js
@@ -4,6 +4,7 @@ import {
   GetObjectCommand,
 } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
@@ -14,7 +15,7 @@ import pRetry from 'p-retry'
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createWorkflowStore(region, bucketName, options = {}) {
-  const s3client = new S3Client({
+  const s3client = getS3Client({
     region,
     ...options,
   })

--- a/upload-api/external-services/ipni-service.js
+++ b/upload-api/external-services/ipni-service.js
@@ -4,6 +4,7 @@ import retry from 'p-retry'
 import map from 'p-map'
 import Queue from 'p-queue'
 import { ok, error } from '@ucanto/server'
+import { getSQSClient } from '../../lib/aws/sqs.js'
 
 /**
  * @typedef {Map<import('multiformats').MultihashDigest, [offset: number, length: number]>} Slices
@@ -18,11 +19,11 @@ const CONCURRENCY = 10
  */
 export const createIPNIService = (blockAdvertisementPublisherQueueConfig, blockIndexWriterQueueConfig, blobsStorage) => {
   const blockAdvertPublisherQueue = new BlockAdvertisementPublisherQueue({
-    client: new SQSClient(blockAdvertisementPublisherQueueConfig),
+    client: getSQSClient(blockAdvertisementPublisherQueueConfig),
     url: blockAdvertisementPublisherQueueConfig.url
   })
   const blockIndexWriterQueue = new BlockIndexWriterQueue({
-    client: new SQSClient(blockIndexWriterQueueConfig),
+    client: getSQSClient(blockIndexWriterQueueConfig),
     url: blockIndexWriterQueueConfig.url
   })
   return useIPNIService(blockAdvertPublisherQueue, blockIndexWriterQueue, blobsStorage)

--- a/upload-api/external-services/ipni-service.js
+++ b/upload-api/external-services/ipni-service.js
@@ -1,4 +1,4 @@
-import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+import { SendMessageCommand } from '@aws-sdk/client-sqs'
 import * as dagJSON from '@ipld/dag-json'
 import retry from 'p-retry'
 import map from 'p-map'
@@ -74,7 +74,7 @@ export class BlockAdvertisementPublisherQueue {
 
   /**
    * @param {object} config
-   * @param {SQSClient} config.client
+   * @param {import('@aws-sdk/client-sqs').SQSClient} config.client
    * @param {URL} config.url
    */
   constructor (config) {
@@ -148,7 +148,7 @@ export class BlockIndexWriterQueue {
 
   /**
    * @param {object} config
-   * @param {SQSClient} config.client
+   * @param {import('@aws-sdk/client-sqs').SQSClient} config.client
    * @param {URL} config.url
    */
   constructor (config) {

--- a/upload-api/functions/admin-metrics.js
+++ b/upload-api/functions/admin-metrics.js
@@ -7,7 +7,7 @@ import { updateAdminMetrics } from '../metrics.js'
 import { createMetricsTable } from '../stores/metrics.js'
 import { createCarStore } from '../buckets/car-store.js'
 import { createAllocationsStorage } from '../stores/allocations.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/upload-api/functions/receipt.js
+++ b/upload-api/functions/receipt.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/serverless'
 import { parseLink } from '@ucanto/server'
 
 import * as Store from '../stores/agent/store.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -52,9 +52,10 @@ export async function receiptGet (event, options = implicitContext()) {
  * @returns {Store.Options}
  */
 export function implicitContext () {
+  const region = process.env.AWS_REGION || 'us-west-2'
   return {
-    connection: { address: {} },
-    region: process.env.AWS_REGION || 'us-west-2',
+    connection: { address: { region } },
+    region,
     buckets: {
       index: { name: mustGetEnv('INVOCATION_BUCKET_NAME') },
       message: { name: mustGetEnv('WORKFLOW_BUCKET_NAME') },

--- a/upload-api/functions/space-metrics.js
+++ b/upload-api/functions/space-metrics.js
@@ -7,7 +7,7 @@ import { updateSpaceMetrics } from '../metrics.js'
 import { createMetricsTable } from '../stores/space-metrics.js'
 import { createCarStore } from '../buckets/car-store.js'
 import { createAllocationsStorage } from '../stores/allocations.js'
-import { mustGetEnv } from './utils.js'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -31,7 +31,6 @@ import { createSubscriptionTable } from '../tables/subscription.js'
 import { createConsumerTable } from '../tables/consumer.js'
 import { createRateLimitTable } from '../tables/rate-limit.js'
 import { createSpaceMetricsTable } from '../tables/space-metrics.js'
-import { mustGetEnv } from './utils.js'
 import { createRevocationsTable } from '../stores/revocations.js'
 import { usePlansStore } from '../stores/plans.js'
 import { createCustomerStore } from '@web3-storage/w3infra-billing/tables/customer.js'
@@ -41,6 +40,7 @@ import { useUsageStore } from '../stores/usage.js'
 import { createStripeBillingProvider } from '../billing.js'
 import { createIPNIService } from '../external-services/ipni-service.js'
 import * as UploadAPI from '@web3-storage/upload-api'
+import { mustGetEnv } from '../../lib/env.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -146,6 +146,7 @@ export async function ucanInvocationRouter(request) {
     store: {
       connection: {
         address: {
+          region: AWS_REGION
         },
       },
       region: AWS_REGION,

--- a/upload-api/functions/ucan.js
+++ b/upload-api/functions/ucan.js
@@ -32,6 +32,7 @@ async function handlerFn(request) {
     store: {
       connection: {
         address: {
+          region: AWS_REGION
         },
       },
       region: AWS_REGION,

--- a/upload-api/functions/utils.js
+++ b/upload-api/functions/utils.js
@@ -1,9 +1,0 @@
-/**
- * @param {string} name 
- * @returns {string}
- */
-export function mustGetEnv (name) {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing env var: ${name}`)
-  return value
-}

--- a/upload-api/functions/validate-email.jsx
+++ b/upload-api/functions/validate-email.jsx
@@ -111,6 +111,7 @@ function createAuthorizeContext () {
     store: {
       connection: {
         address: {
+          region: AWS_REGION
         },
       },
       region: AWS_REGION,

--- a/upload-api/stores/agent/store.js
+++ b/upload-api/stores/agent/store.js
@@ -1,5 +1,4 @@
 import {
-  S3Client,
   PutObjectCommand,
   GetObjectCommand,
   ListObjectsV2Command,
@@ -17,7 +16,7 @@ export { API }
 
 /**
  * @typedef {import('../../../lib/aws/s3.js').Address} Address
- * @typedef {S3Client} Channel
+ * @typedef {import('@aws-sdk/client-s3').S3Client} Channel
  *
  * @typedef {API.Variant<{
  *   channel: Channel

--- a/upload-api/stores/agent/store.js
+++ b/upload-api/stores/agent/store.js
@@ -11,11 +11,12 @@ import {
 import * as CAR from '@ucanto/transport/car'
 import { Invocation, parseLink, Receipt } from '@ucanto/core'
 import * as API from '../../types.js'
+import { getS3Client } from '../../../lib/aws/s3.js'
 
 export { API }
 
 /**
- * @typedef {import('@aws-sdk/client-s3').S3ClientConfig} Address
+ * @typedef {import('../../../lib/aws/s3.js').Address} Address
  * @typedef {S3Client} Channel
  *
  * @typedef {API.Variant<{
@@ -43,7 +44,7 @@ export { API }
  * @returns {Store}
  */
 export const open = ({ connection, region, buckets }) => ({
-  channel: connection.channel ?? new S3Client({ ...connection.address, region }),
+  channel: connection.channel ?? getS3Client({ ...connection.address, region }),
   region,
   buckets,
 })

--- a/upload-api/stores/allocations.js
+++ b/upload-api/stores/allocations.js
@@ -1,5 +1,4 @@
 import {
-  DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
   QueryCommand,
@@ -38,7 +37,7 @@ export const createAllocationsStorage = (region, tableName, options = {}) => {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {AllocationsStorage}
  */

--- a/upload-api/stores/allocations.js
+++ b/upload-api/stores/allocations.js
@@ -9,6 +9,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { RecordKeyConflict, RecordNotFound, StorageOperationFailed } from '@web3-storage/upload-api/errors'
 import { base58btc } from 'multiformats/bases/base58'
 import * as Link from 'multiformats/link'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * @typedef {import('@web3-storage/upload-api/types').AllocationsStorage} AllocationsStorage
@@ -28,7 +29,7 @@ import * as Link from 'multiformats/link'
  * @returns {AllocationsStorage}
  */
 export const createAllocationsStorage = (region, tableName, options = {}) => {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/stores/blobs.js
+++ b/upload-api/stores/blobs.js
@@ -10,6 +10,7 @@ import {
   GetObjectCommand,
 } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { getS3Client } from '../../lib/aws/s3.js'
 
 /**
  * @typedef {import('@web3-storage/upload-api/types').BlobsStorage} BlobsStorage
@@ -39,7 +40,7 @@ const contentKey = (digest) => {
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createBlobsStorage(region, bucketName, options) {
-  const s3 = new S3Client({
+  const s3 = getS3Client({
     region,
     ...options,
   })

--- a/upload-api/stores/blobs.js
+++ b/upload-api/stores/blobs.js
@@ -2,9 +2,7 @@ import { base64pad } from 'multiformats/bases/base64'
 import { base58btc } from 'multiformats/bases/base58'
 import { BlobNotFound } from '@web3-storage/upload-api/blob'
 import { ok, error } from '@ucanto/server'
-
 import {
-  S3Client,
   HeadObjectCommand,
   PutObjectCommand,
   GetObjectCommand,
@@ -51,7 +49,7 @@ export function createBlobsStorage(region, bucketName, options) {
  * This is quite similar with buckets/car-store with few modifications given new key schema
  * and multihash instead of Link.
  *
- * @param {S3Client} s3
+ * @param {import('@aws-sdk/client-s3').S3Client} s3
  * @param {string} bucketName
  * @returns {BlobsStorage & BlobRetriever}
  */

--- a/upload-api/stores/metrics.js
+++ b/upload-api/stores/metrics.js
@@ -3,6 +3,7 @@ import {
   TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb'
 import { marshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * Abstraction layer to handle operations on metrics table.
@@ -13,7 +14,7 @@ import { marshall } from '@aws-sdk/util-dynamodb'
  * @param {string} [options.endpoint]
  */
 export function createMetricsTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/stores/metrics.js
+++ b/upload-api/stores/metrics.js
@@ -1,7 +1,4 @@
-import {
-  DynamoDBClient,
-  TransactWriteItemsCommand,
-} from '@aws-sdk/client-dynamodb'
+import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb'
 import { marshall } from '@aws-sdk/util-dynamodb'
 import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
@@ -23,7 +20,7 @@ export function createMetricsTable (region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('../types').MetricsStore}
  */

--- a/upload-api/stores/revocations.js
+++ b/upload-api/stores/revocations.js
@@ -1,6 +1,5 @@
 import {
   BatchGetItemCommand,
-  DynamoDBClient,
   PutItemCommand,
   UpdateItemCommand
 } from '@aws-sdk/client-dynamodb'
@@ -32,7 +31,7 @@ export function createRevocationsTable (region, tableName, options = {}) {
 const staticRevocationKeys = new Set(Object.keys(revocationTableProps?.fields || {}))
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('@web3-storage/upload-api').RevocationsStorage}
  */

--- a/upload-api/stores/revocations.js
+++ b/upload-api/stores/revocations.js
@@ -7,6 +7,7 @@ import {
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { parseLink } from '@ucanto/core'
 import { revocationTableProps } from '../tables/index.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /** @typedef {import('@ucanto/interface').UCANLink} UCANLink */
 /** @typedef {import('@ucanto/interface').DID} DID */
@@ -20,7 +21,7 @@ import { revocationTableProps } from '../tables/index.js'
  * @param {string} [options.endpoint]
  */
 export function createRevocationsTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/stores/space-metrics.js
+++ b/upload-api/stores/space-metrics.js
@@ -3,6 +3,7 @@ import {
   TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb'
 import { marshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * Abstraction layer to handle operations on metrics table.
@@ -13,7 +14,7 @@ import { marshall } from '@aws-sdk/util-dynamodb'
  * @param {string} [options.endpoint]
  */
 export function createMetricsTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/stores/space-metrics.js
+++ b/upload-api/stores/space-metrics.js
@@ -1,7 +1,4 @@
-import {
-  DynamoDBClient,
-  TransactWriteItemsCommand,
-} from '@aws-sdk/client-dynamodb'
+import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb'
 import { marshall } from '@aws-sdk/util-dynamodb'
 import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
@@ -23,7 +20,7 @@ export function createMetricsTable (region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('../types').SpaceMetricsStore}
  */

--- a/upload-api/tables/consumer.js
+++ b/upload-api/tables/consumer.js
@@ -9,6 +9,7 @@ import { parseLink } from '@ucanto/core'
 import { Failure } from '@ucanto/server'
 import { Schema } from '@ucanto/validator'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * @typedef {import('../types').ConsumerTable} ConsumerTable
@@ -24,7 +25,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
  * @param {string} [options.endpoint]
  */
 export function createConsumerTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/tables/consumer.js
+++ b/upload-api/tables/consumer.js
@@ -1,5 +1,4 @@
 import {
-  DynamoDBClient,
   PutItemCommand,
   DescribeTableCommand,
   QueryCommand,
@@ -47,7 +46,7 @@ export class ConflictError extends Failure {
 
 /**
  * 
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName 
  * @param {import('@ucanto/interface').DID} consumer 
  * @returns {Promise<import('@web3-storage/upload-api').ProviderDID[]>}
@@ -74,7 +73,7 @@ async function getStorageProviders (dynamoDb, tableName, consumer) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {ConsumerTable}
  */

--- a/upload-api/tables/delegations.js
+++ b/upload-api/tables/delegations.js
@@ -1,6 +1,5 @@
 import { base32 } from 'multiformats/bases/base32'
 import {
-  DynamoDBClient,
   QueryCommand,
   BatchWriteItemCommand,
   DescribeTableCommand,
@@ -58,7 +57,7 @@ export function createDelegationsTable (region, tableName, { bucket, invocationB
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @param {object} deps
  * @param {import('../types').DelegationsBucket} deps.bucket

--- a/upload-api/tables/delegations.js
+++ b/upload-api/tables/delegations.js
@@ -21,6 +21,7 @@ import {
   NoDelegationFoundForGivenCidError,
   FailedToDecodeDelegationForGivenCidError
 } from '../errors.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 // Feature flag for looking up delegations in the invocations in which
 // they were originally embeded.
@@ -48,7 +49,7 @@ const DELEGATIONS_FIND_DEFAULT_LIMIT = 1000
  * @param {string} [options.endpoint]
  */
 export function createDelegationsTable (region, tableName, { bucket, invocationBucket, workflowBucket }, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/tables/metrics.js
+++ b/upload-api/tables/metrics.js
@@ -3,6 +3,7 @@ import {
   ScanCommand
 } from '@aws-sdk/client-dynamodb'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * Abstraction layer to handle operations on admin metrics Table.
@@ -13,7 +14,7 @@ import { unmarshall } from '@aws-sdk/util-dynamodb'
  * @param {string} [options.endpoint]
  */
 export function createMetricsTable(region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint
   })

--- a/upload-api/tables/metrics.js
+++ b/upload-api/tables/metrics.js
@@ -1,7 +1,4 @@
-import {
-  DynamoDBClient,
-  ScanCommand
-} from '@aws-sdk/client-dynamodb'
+import { ScanCommand } from '@aws-sdk/client-dynamodb'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
 import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
@@ -23,7 +20,7 @@ export function createMetricsTable(region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('../types').MetricsTable}
  */

--- a/upload-api/tables/rate-limit.js
+++ b/upload-api/tables/rate-limit.js
@@ -4,6 +4,7 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { nanoid } from 'nanoid'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * Abstraction layer to handle operations on Store Table.
@@ -14,7 +15,7 @@ import { nanoid } from 'nanoid'
  * @param {string} [options.endpoint]
  */
 export function createRateLimitTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/tables/rate-limit.js
+++ b/upload-api/tables/rate-limit.js
@@ -1,6 +1,7 @@
 import {
   DeleteItemCommand,
-  DynamoDBClient, PutItemCommand, QueryCommand,
+  PutItemCommand,
+  QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { nanoid } from 'nanoid'
@@ -24,7 +25,7 @@ export function createRateLimitTable (region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('@web3-storage/upload-api').RateLimitsStorage}
  */

--- a/upload-api/tables/space-metrics.js
+++ b/upload-api/tables/space-metrics.js
@@ -1,7 +1,4 @@
-import {
-  DynamoDBClient,
-  GetItemCommand,
-} from '@aws-sdk/client-dynamodb'
+import { GetItemCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { METRICS_NAMES } from '../constants.js'
 import { getDynamoClient } from '../../lib/aws/dynamo.js'
@@ -25,7 +22,7 @@ export function createSpaceMetricsTable(region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {import('../types').SpaceMetricsTable}
  */

--- a/upload-api/tables/space-metrics.js
+++ b/upload-api/tables/space-metrics.js
@@ -4,6 +4,7 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { METRICS_NAMES } from '../constants.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 
 /**
@@ -15,7 +16,7 @@ import { METRICS_NAMES } from '../constants.js'
  * @param {string} [options.endpoint]
  */
 export function createSpaceMetricsTable(region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint
   })

--- a/upload-api/tables/store.js
+++ b/upload-api/tables/store.js
@@ -9,6 +9,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { CID } from 'multiformats/cid'
 import * as Link from 'multiformats/link'
 import { RecordKeyConflict, RecordNotFound } from './lib.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * @typedef {import('@web3-storage/upload-api').StoreTable} StoreTable
@@ -27,7 +28,7 @@ import { RecordKeyConflict, RecordNotFound } from './lib.js'
  * @returns {StoreTable}
  */
 export function createStoreTable(region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/tables/store.js
+++ b/upload-api/tables/store.js
@@ -1,5 +1,4 @@
 import {
-  DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
   DeleteItemCommand,
@@ -37,7 +36,7 @@ export function createStoreTable(region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {StoreTable}
  */

--- a/upload-api/tables/subscription.js
+++ b/upload-api/tables/subscription.js
@@ -1,6 +1,5 @@
 import {
   DescribeTableCommand,
-  DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
   QueryCommand,
@@ -43,7 +42,7 @@ export function createSubscriptionTable (region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {SubscriptionTable}
  */

--- a/upload-api/tables/subscription.js
+++ b/upload-api/tables/subscription.js
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/client-dynamodb'
 import { Failure } from '@ucanto/server'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * @typedef {import('../types').SubscriptionTable} SubscriptionTable
@@ -33,7 +34,7 @@ export class ConflictError extends Failure {
  * @param {string} [options.endpoint]
  */
 export function createSubscriptionTable (region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/tables/upload.js
+++ b/upload-api/tables/upload.js
@@ -8,6 +8,7 @@ import {
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { CID } from 'multiformats/cid'
 import { RecordNotFound } from './lib.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * @typedef {import('@web3-storage/upload-api').UploadTable} UploadTable
@@ -25,7 +26,7 @@ import { RecordNotFound } from './lib.js'
  * @returns {UploadTable}
  */
 export function createUploadTable(region, tableName, options = {}) {
-  const dynamoDb = new DynamoDBClient({
+  const dynamoDb = getDynamoClient({
     region,
     endpoint: options.endpoint,
   })

--- a/upload-api/tables/upload.js
+++ b/upload-api/tables/upload.js
@@ -1,5 +1,4 @@
 import {
-  DynamoDBClient,
   UpdateItemCommand,
   GetItemCommand,
   DeleteItemCommand,
@@ -34,7 +33,7 @@ export function createUploadTable(region, tableName, options = {}) {
 }
 
 /**
- * @param {DynamoDBClient} dynamoDb
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @returns {UploadTable}
  */


### PR DESCRIPTION
This is a fairly mechanical change to replace all calls to `new SQSClient/DynamoDBClient/S3Client` with a call to a function that creates and instance and caches it - similarly to https://github.com/storacha-network/w3infra/pull/399

It also moves `mustGetEnv` into the same shared lib folder - we have copied this function an insane amount of times, it was very wet, not DRY at all.