### PR TITLE
fix(filecoin): increase metrics consumer parallelization factor

### DIFF
--- a/stacks/filecoin-stack.js
+++ b/stacks/filecoin-stack.js
@@ -319,6 +319,7 @@ export function FilecoinStack({ stack, app }) {
     permissions: [adminMetricsTable, workflowBucket, invocationBucket],
     handler: 'filecoin/functions/metrics-aggregate-offer-and-accept-total.consumer',
     deadLetterQueue: metricsAggregateTotalDLQ.cdk.queue,
+    timeout: 3 * 60,
   })
 
   ucanStream.addConsumers(stack, {
@@ -326,7 +327,8 @@ export function FilecoinStack({ stack, app }) {
       function: metricsAggregateTotalConsumer,
       cdk: {
         eventSource: {
-          ...(getEventSourceConfig(stack))
+          ...(getEventSourceConfig(stack)),
+          parallelizationFactor: 10
         }
       }
     }


### PR DESCRIPTION
The filecoin metrics consumer has been observed to take up to 10 seconds to execute and appears to be the reason that iterator age is continuously increasing.

This PR increases the parallelization factor so that multiple executions can consume the stream in parallel. It also increases the timeout for the lambda in line with other timeouts in the same stack. This is because errors occur when it takes 10 seconds, and it does not ever take longer - hinting that it sometimes needs longer.

Note: I believe it is fine to do this in parallel because the lambda simply issues increment (ADD) instructions to dynamo for the metrics, not SET.

<img width="403" alt="Screenshot 2024-07-05 at 11 51 40" src="https://github.com/storacha-network/w3infra/assets/152863/34b7828d-0ed7-4a7b-8ecb-e888a8f4e4ab">

<img width="404" alt="Screenshot 2024-07-05 at 11 55 30" src="https://github.com/storacha-network/w3infra/assets/152863/a9b8839e-084b-4f97-946c-8293c7e418e4">