### PR TITLE
feat(billing): filter by type receipt

### DIFF
--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -1,5 +1,5 @@
 import { use, Cron, Queue, Function, Config, Api } from 'sst/constructs'
-import { StartingPosition } from 'aws-cdk-lib/aws-lambda'
+import { StartingPosition, FilterCriteria, FilterRule } from 'aws-cdk-lib/aws-lambda'
 import { Duration } from 'aws-cdk-lib'
 import { UcanInvocationStack } from './ucan-invocation-stack.js'
 import { BillingDbStack } from './billing-db-stack.js'
@@ -109,8 +109,14 @@ export function BillingStack ({ stack, app }) {
         eventSource: {
           batchSize: 1,
           startingPosition: StartingPosition.LATEST,
-          parallelizationFactor: 10
-        }
+          filters: [
+            FilterCriteria.filter({
+              data: {
+                type: FilterRule.isEqual('receipt')
+              }
+            })
+          ]
+        },
       }
     }
   })


### PR DESCRIPTION
The UCAN stream handler for the billing stack cannot keep up with the number of items it needs to consume - iterator age is constantly increasing.

However it only needs to consider receipts (we already drop [non-reciept types here](https://github.com/storacha-network/w3infra/blob/d4166646772a2e51755f8a9a6345d52ae981c22f/billing/lib/ucan-stream.js#L16)).

This PR uses "filters" to reduce the number of invocations the handler receives, which should hopefully give it more time to process receipts it cares about.

More info: https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-kinesis