### PR TITLE
feat: add filters for metrics consumers

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -6,7 +6,7 @@ import {
   use
 } from 'sst/constructs'
 
-import { StartingPosition } from 'aws-cdk-lib/aws-lambda'
+import { StartingPosition, FilterCriteria, FilterRule } from 'aws-cdk-lib/aws-lambda'
 import { UploadDbStack } from './upload-db-stack.js'
 import { BillingDbStack } from './billing-db-stack.js'
 import { CarparkStack } from './carpark-stack.js'
@@ -186,7 +186,14 @@ export function UploadApiStack({ stack, app }) {
         eventSource: {
           ...(getEventSourceConfig(stack)),
           // Override where to begin consuming the stream to latest as we already are reading from this stream
-          startingPosition: StartingPosition.LATEST
+          startingPosition: StartingPosition.LATEST,
+          filters: [
+            FilterCriteria.filter({
+              data: {
+                type: FilterRule.isEqual('receipt')
+              }
+            })
+          ]
         }
       }
     },
@@ -196,7 +203,14 @@ export function UploadApiStack({ stack, app }) {
         eventSource: {
           ...(getEventSourceConfig(stack)),
           // Override where to begin consuming the stream to latest as we already are reading from this stream
-          startingPosition: StartingPosition.LATEST
+          startingPosition: StartingPosition.LATEST,
+          filters: [
+            FilterCriteria.filter({
+              data: {
+                type: FilterRule.isEqual('receipt')
+              }
+            })
+          ]
         }
       }
     },


### PR DESCRIPTION
The admin/space metrics deal only with receipts and discard anything that is not a receipt.

This should (hopefully) reduce iterator age and lambda invocations bill.

e.g. current admin metrics iterator age:

<img width="387" alt="Screenshot 2024-07-15 at 12 45 22" src="https://github.com/user-attachments/assets/3f0f3e92-167a-4e8f-9b5a-3c2ad20e531b">
