### PR TITLE
feat: use batching for billing UCAN stream handler

### DIFF
--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -43,7 +43,7 @@ export interface SpaceDiffListKey {
 }
 
 export type SpaceDiffStore =
-  & StoreTransactBatchPutter<SpaceDiff>
+  & StoreBatchPutter<SpaceDiff>
   & StoreLister<SpaceDiffListKey, SpaceDiff>
 
 /** Captures size of a space at a given point in time. */
@@ -306,15 +306,17 @@ export interface StorePutter<T> {
 }
 
 /**
- * StoreTransactBatchPutter allows multiple items to be put in the store
- * transactionally, so that either all of them succeed, or all of them fail.
+ * StoreBatchPutter allows multiple items to be put in the store. Note: this is
+ * not transactional. A failure may mean 1 or more records succeeded to
+ * be written.
  */
-export interface StoreTransactBatchPutter<T> {
+export interface StoreBatchPutter<T> {
   /**
-   * Puts multiple items into the store by their key. Either all of them
-   * succeed, or all of them fail.
+   * Puts multiple items into the store by their key. Note: this is
+   * not transactional. A failure may mean 1 or more records succeeded to
+   * be written.
    */
-  transactBatchPut: (rec: Iterable<T>) => Promise<Result<Unit, InsufficientRecords|EncodeFailure|StoreOperationFailure|Failure>>
+  batchPut: (rec: Iterable<T>) => Promise<Result<Unit, InsufficientRecords|EncodeFailure|StoreOperationFailure|Failure>>
 }
 
 /** StoreGetter allows a single item to be retrieved by it's key. */

--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -43,7 +43,7 @@ export interface SpaceDiffListKey {
 }
 
 export type SpaceDiffStore =
-  & StorePutter<SpaceDiff>
+  & StoreTransactBatchPutter<SpaceDiff>
   & StoreLister<SpaceDiffListKey, SpaceDiff>
 
 /** Captures size of a space at a given point in time. */
@@ -294,10 +294,27 @@ export interface RecordNotFound<K> extends Failure {
   key: K
 }
 
+/** Not enough records were provided for the operation. */
+export interface InsufficientRecords extends Failure {
+  name: 'InsufficientRecords'
+}
+
 /** StorePutter allows a single item to be put in the store by it's key. */
 export interface StorePutter<T> {
   /** Puts a single item into the store by it's key */
   put: (rec: T) => Promise<Result<Unit, EncodeFailure|StoreOperationFailure|Failure>>
+}
+
+/**
+ * StoreTransactBatchPutter allows multiple items to be put in the store
+ * transactionally, so that either all of them succeed, or all of them fail.
+ */
+export interface StoreTransactBatchPutter<T> {
+  /**
+   * Puts multiple items into the store by their key. Either all of them
+   * succeed, or all of them fail.
+   */
+  transactBatchPut: (rec: Iterable<T>) => Promise<Result<Unit, InsufficientRecords|EncodeFailure|StoreOperationFailure|Failure>>
 }
 
 /** StoreGetter allows a single item to be retrieved by it's key. */

--- a/billing/lib/ucan-stream.js
+++ b/billing/lib/ucan-stream.js
@@ -87,12 +87,13 @@ export const storeSpaceUsageDeltas = async (deltas, ctx) => {
         insertedAt: new Date()
       })
     }
-    return { ok: diffs }
+    return { ok: diffs, error: undefined }
   }))
 
   const spaceDiffs = []
   for (const res of spaceDiffResults) {
-    if (res.ok) spaceDiffs.push(...res.ok)
+    if (res.error) return res
+    spaceDiffs.push(...res.ok)
   }
 
   return ctx.spaceDiffStore.batchPut(spaceDiffs)

--- a/billing/lib/ucan-stream.js
+++ b/billing/lib/ucan-stream.js
@@ -95,7 +95,7 @@ export const storeSpaceUsageDeltas = async (deltas, ctx) => {
     if (res.ok) spaceDiffs.push(...res.ok)
   }
 
-  return ctx.spaceDiffStore.transactBatchPut(spaceDiffs)
+  return ctx.spaceDiffStore.batchPut(spaceDiffs)
 }
 
 /**

--- a/billing/tables/client.js
+++ b/billing/tables/client.js
@@ -1,4 +1,4 @@
-import { BatchWriteItemCommand, DynamoDBClient, GetItemCommand, PutItemCommand, QueryCommand, ScanCommand, TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb'
+import { BatchWriteItemCommand, DynamoDBClient, GetItemCommand, PutItemCommand, QueryCommand, ScanCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall, convertToAttr } from '@aws-sdk/util-dynamodb'
 import retry from 'p-retry'
 import { InsufficientRecords, RecordNotFound, StoreOperationFailure } from './lib.js'

--- a/billing/tables/lib.js
+++ b/billing/tables/lib.js
@@ -35,3 +35,19 @@ export class RecordNotFound extends Failure {
     return { ...super.toJSON(), key: this.key }
   }
 }
+
+export class InsufficientRecords extends Failure {
+  /**
+   * @param {string} [message] Context for the message.
+   * @param {ErrorOptions} [options]
+   */
+  constructor (message, options) {
+    super(undefined, options)
+    this.name = /** @type {const} */ ('InsufficientRecords')
+    this.detail = message
+  }
+
+  describe () {
+    return this.detail ?? 'insufficient records were provided for the operation'
+  }
+}

--- a/billing/tables/space-diff.js
+++ b/billing/tables/space-diff.js
@@ -1,4 +1,4 @@
-import { createStoreListerClient, createStorePutterClient } from './client.js'
+import { createStoreListerClient, createStoreTransactBatchPutterClient } from './client.js'
 import { validate, encode, lister, decode } from '../data/space-diff.js'
 
 /**
@@ -36,6 +36,6 @@ export const spaceDiffTableProps = {
  * @returns {import('../lib/api').SpaceDiffStore}
  */
 export const createSpaceDiffStore = (conf, { tableName }) => ({
-  ...createStorePutterClient(conf, { tableName, validate, encode }),
+  ...createStoreTransactBatchPutterClient(conf, { tableName, validate, encode }),
   ...createStoreListerClient(conf, { tableName, encodeKey: lister.encodeKey, decode })
 })

--- a/billing/tables/space-diff.js
+++ b/billing/tables/space-diff.js
@@ -1,4 +1,4 @@
-import { createStoreListerClient, createStoreTransactBatchPutterClient } from './client.js'
+import { createStoreBatchPutterClient, createStoreListerClient } from './client.js'
 import { validate, encode, lister, decode } from '../data/space-diff.js'
 
 /**
@@ -36,6 +36,6 @@ export const spaceDiffTableProps = {
  * @returns {import('../lib/api').SpaceDiffStore}
  */
 export const createSpaceDiffStore = (conf, { tableName }) => ({
-  ...createStoreTransactBatchPutterClient(conf, { tableName, validate, encode }),
+  ...createStoreBatchPutterClient(conf, { tableName, validate, encode }),
   ...createStoreListerClient(conf, { tableName, encodeKey: lister.encodeKey, decode })
 })

--- a/billing/test/lib/space-billing-queue.js
+++ b/billing/test/lib/space-billing-queue.js
@@ -14,7 +14,7 @@ export const test = {
     const to = startOfMonth(now)
     const delta = 1024 * 1024 * 1024 // 1GiB
 
-    await ctx.spaceDiffStore.put({
+    await ctx.spaceDiffStore.transactBatchPut([{
       provider: consumer.provider,
       space: consumer.consumer,
       subscription: consumer.subscription,
@@ -22,7 +22,7 @@ export const test = {
       delta,
       receiptAt: from,
       insertedAt: new Date()
-    })
+    }])
 
     /** @type {import('../../lib/api.js').SpaceBillingInstruction} */
     const instruction = {
@@ -75,28 +75,29 @@ export const test = {
       insertedAt: new Date()
     })
 
-    // add 1GiB
-    await ctx.spaceDiffStore.put({
-      provider: consumer.provider,
-      space: consumer.consumer,
-      subscription: consumer.subscription,
-      cause: randomLink(),
-      delta,
-      receiptAt: from,
-      insertedAt: new Date()
-    })
-
-    // remove 1GiB
-    await ctx.spaceDiffStore.put({
-      provider: consumer.provider,
-      space: consumer.consumer,
-      subscription: consumer.subscription,
-      cause: randomLink(),
-      delta: -delta,
-      // removed exactly half way through the month
-      receiptAt: new Date(from.getTime() + ((to.getTime() - from.getTime()) / 2)),
-      insertedAt: new Date()
-    })
+    await ctx.spaceDiffStore.transactBatchPut([
+      // add 1GiB
+      {
+        provider: consumer.provider,
+        space: consumer.consumer,
+        subscription: consumer.subscription,
+        cause: randomLink(),
+        delta,
+        receiptAt: from,
+        insertedAt: new Date()
+      },
+      // remove 1GiB
+      {
+        provider: consumer.provider,
+        space: consumer.consumer,
+        subscription: consumer.subscription,
+        cause: randomLink(),
+        delta: -delta,
+        // removed exactly half way through the month
+        receiptAt: new Date(from.getTime() + ((to.getTime() - from.getTime()) / 2)),
+        insertedAt: new Date()
+      }
+    ])
 
     /** @type {import('../../lib/api.js').SpaceBillingInstruction} */
     const instruction = {
@@ -157,7 +158,7 @@ export const test = {
       return yest
     }
 
-    await ctx.spaceDiffStore.put({
+    await ctx.spaceDiffStore.transactBatchPut([{
       provider: consumer.provider,
       space: consumer.consumer,
       subscription: consumer.subscription,
@@ -166,7 +167,7 @@ export const test = {
       // store/add 24h prior to end of billing
       receiptAt: yesterday(to),
       insertedAt: new Date()
-    })
+    }])
 
     /** @type {import('../../lib/api.js').SpaceBillingInstruction} */
     const instruction = {

--- a/billing/test/lib/space-billing-queue.js
+++ b/billing/test/lib/space-billing-queue.js
@@ -14,7 +14,7 @@ export const test = {
     const to = startOfMonth(now)
     const delta = 1024 * 1024 * 1024 // 1GiB
 
-    await ctx.spaceDiffStore.transactBatchPut([{
+    await ctx.spaceDiffStore.batchPut([{
       provider: consumer.provider,
       space: consumer.consumer,
       subscription: consumer.subscription,
@@ -75,7 +75,7 @@ export const test = {
       insertedAt: new Date()
     })
 
-    await ctx.spaceDiffStore.transactBatchPut([
+    await ctx.spaceDiffStore.batchPut([
       // add 1GiB
       {
         provider: consumer.provider,
@@ -158,7 +158,7 @@ export const test = {
       return yest
     }
 
-    await ctx.spaceDiffStore.transactBatchPut([{
+    await ctx.spaceDiffStore.batchPut([{
       provider: consumer.provider,
       space: consumer.consumer,
       subscription: consumer.subscription,

--- a/billing/test/lib/ucan-stream.js
+++ b/billing/test/lib/ucan-stream.js
@@ -2,7 +2,7 @@ import { Schema } from '@ucanto/core'
 import * as ServiceBlobCaps from '@web3-storage/capabilities/web3.storage/blob'
 import * as BlobCaps from '@web3-storage/capabilities/blob'
 import * as StoreCaps from '@web3-storage/capabilities/store'
-import { findSpaceUsageDeltas, storeSpaceUsageDelta } from '../../lib/ucan-stream.js'
+import { findSpaceUsageDeltas, storeSpaceUsageDeltas } from '../../lib/ucan-stream.js'
 import { randomConsumer } from '../helpers/consumer.js'
 import { randomLink } from '../helpers/dag.js'
 import { randomDID, randomDIDKey } from '../helpers/did.js'
@@ -174,11 +174,8 @@ export const test = {
     }]
 
     const deltas = findSpaceUsageDeltas(receipts)
-
-    for (const d of deltas) {
-      const res = await storeSpaceUsageDelta(d, ctx)
-      assert.ok(res.ok)
-    }
+    const storeDeltasRes = await storeSpaceUsageDeltas(deltas, ctx)
+    assert.ok(storeDeltasRes.ok)
 
     const res = await ctx.spaceDiffStore.list({
       provider: consumer.provider,
@@ -230,11 +227,8 @@ export const test = {
     }]
 
     const deltas = findSpaceUsageDeltas(receipts)
-
-    for (const d of deltas) {
-      const res = await storeSpaceUsageDelta(d, ctx)
-      assert.ok(res.ok)
-    }
+    const storeDeltasRes = await storeSpaceUsageDeltas(deltas, ctx)
+    assert.equal(storeDeltasRes.error?.name, 'InsufficientRecords')
 
     const res = await ctx.spaceDiffStore.list({
       provider: consumer.provider,

--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -107,7 +107,7 @@ export function BillingStack ({ stack, app }) {
       function: ucanStreamHandler,
       cdk: {
         eventSource: {
-          batchSize: 1,
+          batchSize: 50,
           startingPosition: StartingPosition.LATEST,
           filters: [
             FilterCriteria.filter({

--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -107,7 +107,7 @@ export function BillingStack ({ stack, app }) {
       function: ucanStreamHandler,
       cdk: {
         eventSource: {
-          batchSize: 50,
+          batchSize: 25, // max dynamo BatchWriteItems size
           startingPosition: StartingPosition.LATEST,
           filters: [
             FilterCriteria.filter({

--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -108,6 +108,7 @@ export function BillingStack ({ stack, app }) {
       cdk: {
         eventSource: {
           batchSize: 25, // max dynamo BatchWriteItems size
+          bisectBatchOnError: true,
           startingPosition: StartingPosition.LATEST,
           filters: [
             FilterCriteria.filter({


### PR DESCRIPTION
This enables the UCAN stream handler to accept messages in batches, which should hopefully speed up processing of the stream and stop the backlog from growing.

It's ok for the whole batch to be retried on failure since the primary key does not change over time, so any records that succeeded to be written in a failed batch will just be overwritten on retry.