### PR TITLE
feat: integrate latest filecoin-api dependency

### DIFF
--- a/filecoin/package.json
+++ b/filecoin/package.json
@@ -17,7 +17,7 @@
     "@ucanto/principal": "^9.0.1",
     "@ucanto/transport": "^9.1.1",
     "@web3-storage/data-segment": "^5.1.0",
-    "@web3-storage/filecoin-api": "^7.1.1",
+    "@web3-storage/filecoin-api": "^7.2.0",
     "@web3-storage/filecoin-client": "^3.3.3",
     "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
     "multiformats": "^13.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,7 @@
         "@ucanto/principal": "^9.0.1",
         "@ucanto/transport": "^9.1.1",
         "@web3-storage/data-segment": "^5.1.0",
-        "@web3-storage/filecoin-api": "^7.1.1",
+        "@web3-storage/filecoin-api": "^7.2.0",
         "@web3-storage/filecoin-client": "^3.3.3",
         "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
         "multiformats": "^13.1.0",
@@ -11256,9 +11256,9 @@
       }
     },
     "node_modules/@web3-storage/filecoin-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-7.1.1.tgz",
-      "integrity": "sha512-rTzqBJ7kd8J6kjg9Ou4ao0eDHbM5EiYutPnjCCuRoTxV6DQ9UBjZzr4TYbuxXa8wwf4eRTfV9uDULo+gAtbLDg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-7.2.0.tgz",
+      "integrity": "sha512-0tr+vlLXQn4vbHZR2Sxxr62fKW60TejQyH3ZG1CNCFLhLkBg4pXTYSu5rxijYg3ob8DHkejKp7hXMgPQhFzOHw==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
         "@ucanto/client": "^9.0.1",

--- a/tools/get-oldest-pieces-pending-deals.js
+++ b/tools/get-oldest-pieces-pending-deals.js
@@ -23,7 +23,7 @@ export async function getOldestPiecesPendingDeals () {
 
   // List first 10 entries
   console.log('10 oldest pieces pending deals')
-  for (const piece of submittedPieces.ok.slice(0, 10)) {
+  for (const piece of submittedPieces.ok.results.slice(0, 10)) {
     console.log(`${piece.piece.link()} at ${piece.insertedAt}`)
   }
 }


### PR DESCRIPTION
Updates the piece store to use paginated queries as required in v7.2.0 of `filecoin-api`.